### PR TITLE
Fix issues #107 and #108

### DIFF
--- a/libgsync/drive/__init__.py
+++ b/libgsync/drive/__init__.py
@@ -345,6 +345,8 @@ class Drive(object):
 
         if credentials is None:
             credentials = self._obtain_credentials()
+            if storage is not None:
+                storage.put(credentials)
 
         debug("Authenticating")
         import httplib2

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'docopt >= 0.6.0',
         'google-api-python-client >= 1.2, < 1.5.0',
         'httplib2 >= 0.8',
-        'oauth2client >= 1.1',
+        'oauth2client >= 1.1, < 4.0.0',
         'python-dateutil >= 1.5',
         'python-gflags >= 2.0',
         'python-magic >= 0.4.6',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     install_requires = [
         'docopt >= 0.6.0',
-        'google-api-python-client >= 1.2',
+        'google-api-python-client >= 1.2, < 1.5.0',
         'httplib2 >= 0.8',
         'oauth2client >= 1.1',
         'python-dateutil >= 1.5',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires = [
         'docopt >= 0.6.0',
         'google-api-python-client >= 1.2, < 1.5.0',
-        'httplib2 >= 0.8',
+        'httplib2 >= 0.8, < 0.16.0',
         'oauth2client >= 1.1, < 4.0.0',
         'python-dateutil >= 1.5',
         'python-gflags >= 2.0',


### PR DESCRIPTION
This pull request fixes the following issues:

1.  Issue #107: the setup file is modified to ensure that the versions of the dependencies stay consistent. If we let Python download the newest versions of the external dependencies, gsync breaks.
2.  Issue #108: the credentials are not stored after providing the verification link from Google and gsync keeps asking for them; the `Drive` class is modified to fix it.
